### PR TITLE
グループのメッセージのviewへの反映

### DIFF
--- a/app/assets/stylesheets/partials/_messages-main-header.scss
+++ b/app/assets/stylesheets/partials/_messages-main-header.scss
@@ -16,6 +16,7 @@
         &__member{
         @include color-size-weight($light_gray_color, 12px);
         margin-bottom:0;
+        padding-right: 5px;
         list-style-type: none;
         }
       }

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,4 +4,12 @@ class Group < ApplicationRecord
   has_many :members
   has_many :users, through: :members
   has_many :messages
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.body? ? last_message.body : "画像が投稿されています。"
+    else
+      "まだメッセージはありません。"
+    end
+  end
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -3,7 +3,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
   
-  process resize_to_fit: [800, 800]
+  
 
   # Choose what kind of storage to use for this uploader:
   storage :file
@@ -33,6 +33,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Create different versions of your uploaded files:
   # version :thumb do
   #   process resize_to_fit: [50, 50]
+  process resize_to_fit: [800, 800]
   # end
 
   # Add a white list of extensions which are allowed to be uploaded.

--- a/app/views/messages/index.haml
+++ b/app/views/messages/index.haml
@@ -3,7 +3,8 @@
   .main-contents
     .main-header
       .main-content
-        %p.main-content__group-name= @group.name
+        %p.main-content__group-name
+          = @group.name
         %ul.main-members 
           %li.main-members__member.main-members__member-title Member：
           - @group.users.each do |user|

--- a/app/views/messages/index.haml
+++ b/app/views/messages/index.haml
@@ -5,9 +5,10 @@
       .main-content
         %p.main-content__group-name= @group.name
         %ul.main-members 
-          %li.main-members__member Member :
-          %li.main-members__member name
-          %li.main-members__member ,name
+          %li.main-members__member.main-members__member-title Member：
+          - @group.users.each do |user|
+            %li.main-members__member
+              = user.name
       = link_to edit_group_path(@group) do
         .main-header__edit-button Edit
     .main-messages

--- a/app/views/messages/index.haml
+++ b/app/views/messages/index.haml
@@ -11,9 +11,7 @@
       = link_to edit_group_path(@group) do
         .main-header__edit-button Edit
     .main-messages
-      = render partial:"shared/main-message"
-      = render partial:"shared/main-message"
-      = render partial:"shared/main-message"
+      = render partial:"shared/message", collection: @messages
     .main-footer
       .main-form
         = form_for [@group, @message], html: {class: "input-box"} do |f|

--- a/app/views/shared/_main-message.haml
+++ b/app/views/shared/_main-message.haml
@@ -1,5 +1,0 @@
-.main-message
-  .message-details
-    %p.message-details__user Test
-    %p.message-details__informetion 2019/06/01
-  %p.main-message__text test message

--- a/app/views/shared/_message.haml
+++ b/app/views/shared/_message.haml
@@ -1,5 +1,7 @@
 .main-message
   .message-details
     %p.message-details__user
+      = message.user.name
     %p.message-details__informetion
+      = message.created_at.strftime("%Y/%m/%d %H:%M")
     %p.main-message__text 

--- a/app/views/shared/_message.haml
+++ b/app/views/shared/_message.haml
@@ -1,0 +1,5 @@
+.main-message
+  .message-details
+    %p.message-details__user
+    %p.message-details__informetion
+    %p.main-message__text 

--- a/app/views/shared/_message.haml
+++ b/app/views/shared/_message.haml
@@ -4,4 +4,6 @@
       = message.user.name
     %p.message-details__informetion
       = message.created_at.strftime("%Y/%m/%d %H:%M")
+  - if message.body.present?
     %p.main-message__text 
+      = message.body

--- a/app/views/shared/_message.haml
+++ b/app/views/shared/_message.haml
@@ -7,3 +7,4 @@
   - if message.body.present?
     %p.main-message__text 
       = message.body
+  = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/shared/_side-contents.html.haml
+++ b/app/views/shared/_side-contents.html.haml
@@ -1,6 +1,7 @@
 .side-contents
   .side-header
-    %p.side-header__user-name= current_user.name
+    %p.side-header__user-name
+      = current_user.name
     %ul.side-lists
       %li.side-lists__list= link_to content_tag(:p, fa_icon("edit")), new_group_path, class: "side-lists__list--link"
       %li.side-lists__list= link_to content_tag(:p, fa_icon("cog")), edit_user_path(current_user), class: "side-lists__list--link"

--- a/app/views/shared/_side-contents.html.haml
+++ b/app/views/shared/_side-contents.html.haml
@@ -9,5 +9,7 @@
     - current_user.groups.each do |group|
       = link_to group_messages_path(group) do
         .side-group
-          %p.side-group__group-name= group.name
-          %p.side-group__new-message メッセージはまだありません。
+          %p.side-group__group-name
+            = group.name
+          %p.side-group__new-message
+            = group.show_last_message


### PR DESCRIPTION
# WHAT
グループメッセージを表示させる。
# WHY
グループのメッセージが保存されたため、一覧に表示する。（過去の投稿も含める）
履歴として保存して、いつでも見られる状態になる。
ユーザが所属しているグループが一覧できる。
最新の投稿が確認できるようになる。